### PR TITLE
Add support for testing @glimmer/compiler directly

### DIFF
--- a/bench/compare-template-compile-time.js
+++ b/bench/compare-template-compile-time.js
@@ -1,15 +1,58 @@
 'use strict';
 
 const fg = require('fast-glob');
+const path = require('path');
 const fs = require('fs');
 
-const {
-  precompile: precompile_3_24,
-} = require('ember-source-3-24/dist/ember-template-compiler');
+const pkg = require('../package.json');
 
-const {
-  precompile: precompile_3_25,
-} = require('ember-source-3-25/dist/ember-template-compiler');
+/**
+  @typdef CompilersToTest
+
+  @property {'@glimmer/component' | 'ember-source'} package
+  @property {string} version;
+  @property {(template: string) => void} precompile;
+  @property {Array} plugins the ASTPlugin type from @glimmer/syntax
+*/
+
+/**
+  Create an array of compiler functions to try out, these objects are in this format:
+
+ @returns CompilersToTest
+*/
+function getCompilers() {
+  return Object.entries(pkg.devDependencies).reduce((memo, [label]) => {
+    const compilerPkg = require(`${label}/package.json`);
+
+    let precompile;
+    let buildCompileOptions = (options) => options;
+
+    if (compilerPkg.name === 'ember-source') {
+      precompile = require(`${label}/dist/ember-template-compiler`).precompile;
+    } else if (compilerPkg.name === '@glimmer/compiler') {
+      precompile = require(label).precompile;
+
+      const emberPackage = label.substring('glimmer-component'.length);
+
+      buildCompileOptions =
+        require(`${emberPackage}/dist/ember-template-compiler`).compileOptions;
+    } else {
+      return memo;
+    }
+
+    const compilerInfo = {
+      package: compilerPkg.name,
+      version: compilerPkg.version,
+      precompile,
+      buildCompileOptions,
+    };
+    memo.push(compilerInfo);
+
+    return memo;
+  }, []);
+}
+
+const compilers = getCompilers();
 
 async function getAllTemplates() {
   const templates = await fg(['templates/**/*.hbs', '!**/node_modules/**'], {
@@ -17,20 +60,38 @@ async function getAllTemplates() {
   });
 
   return Promise.all(
-    templates.map((filePath) =>
-      fs.promises.readFile(filePath, 'utf-8').then((fileContent) => ({
+    templates.map(async (filePath) => {
+      const relativePath = path.relative(process.cwd(), filePath);
+
+      const fileContent = await fs.promises.readFile(filePath, 'utf-8');
+
+      return {
         filePath,
         fileContent,
-      }))
-    )
+        relativePath,
+      };
+    })
   );
 }
 
-function measure({ precompile, templates }) {
+function measure({ precompile, buildCompileOptions }, templates) {
   const start = Date.now();
 
-  templates.forEach(({ fileContent }) => {
-    precompile(fileContent);
+  templates.forEach(({ relativePath, fileContent }) => {
+    precompile(
+      fileContent,
+      buildCompileOptions({
+        // common options from ember-cli-htmlbars
+        //
+        // https://github.com/ember-cli/ember-cli-htmlbars/blob/6b69feff73b879aa06bd402b914c5627dc5ba481/lib/template-compiler-plugin.js#L68-L83
+        // https://github.com/ember-cli/ember-cli-htmlbars/blob/6b69feff73b879aa06bd402b914c5627dc5ba481/lib/colocated-broccoli-plugin.js#L126-L135
+        contents: fileContent,
+        moduleName: relativePath,
+        parseOptions: {
+          srcName: relativePath,
+        },
+      })
+    );
   });
 
   return Date.now() - start;
@@ -41,12 +102,15 @@ function measure({ precompile, templates }) {
   const templates = await getAllTemplates();
   console.log(`Found ${templates.length} templates`);
 
-  console.log('Measuring precompile time using `ember-source@3.24`');
-  const timing_3_24 = measure({ precompile: precompile_3_24, templates });
+  let timingLogs = [];
 
-  console.log('Measuring precompile time using `ember-source@3.25`');
-  const timing_3_25 = measure({ precompile: precompile_3_25, templates });
+  compilers.forEach((compilerInfo) => {
+    let displayName = `${compilerInfo.package}@${compilerInfo.version}`;
+    console.log(`Measuring precompile time using '${displayName}'`);
+    const timing = measure(compilerInfo, templates);
 
-  console.log('Total precompile time using `ember-source@3.24`', timing_3_24);
-  console.log('Total precompile time using `ember-source@3.25`', timing_3_25);
+    timingLogs.push([`Total precompile time using '${displayName}'`, timing]);
+  });
+
+  timingLogs.forEach((info) => console.log(...info));
 })();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   "devDependencies": {
     "ember-source-3-24": "npm:ember-source@3.24.5",
     "ember-source-3-25": "npm:ember-source@3.25.4",
+    "ember-source-3-28": "npm:ember-source@3.28.1",
     "fast-glob": "^3.2.7",
+    "glimmer-compiler-ember-source-3-28": "npm:@glimmer/compiler@0.80.0",
+    "glimmer-compiler-ember-source-3-24": "npm:@glimmer/compiler@0.65.3",
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
     "prettier": "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,12 +944,102 @@
   resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.2.0.tgz#a039f542dc14c8e8299c81cd5abba95e2459cfa6"
   integrity sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==
 
+"@glimmer/env@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
+
+"@glimmer/interfaces@0.65.3":
+  version "0.65.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.65.3.tgz#ef3df40b42ab8b6dc36efea81652abddda72f23c"
+  integrity sha512-DP38dx0ai3xBPdYXRxxv3Ix5CbQHJZwI8PPUkDXv0pyua7/XEsSkiv7heXaaXgihSOGGHgrUa96/Nu82R6UtYw==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/interfaces@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.80.0.tgz#eabc7551ffe7ad27c44ba96d39e2af6ebf01c942"
+  integrity sha512-evD9aVhYacFe/lD/FzaPs0CuuIgkr17+KbOCWDeEMXW0q2FnrLiQET40eP5nyhGLELhKE62mlIzdGmleUR6XYg==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/syntax@0.65.3":
+  version "0.65.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.65.3.tgz#01fe7e20dc8ffd9263d51a22c4a95ac263133cea"
+  integrity sha512-2AdC5rJy+z1e6G29BXy2MLa9dXQgUTalH8qy1UkQ54stwQ8r3ZI6aO0IQYh5tiO0Hu2hAY/xy7UyjZc256zwQg==
+  dependencies:
+    "@glimmer/interfaces" "0.65.3"
+    "@glimmer/util" "0.65.3"
+    "@handlebars/parser" "^1.1.0"
+    simple-html-tokenizer "^0.5.10"
+
+"@glimmer/syntax@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.80.0.tgz#5f9c2e5824fdc8f88ec3e71861598c339b6777c1"
+  integrity sha512-LP8I5MmcguUiHhahyF96dgjKrPE6l1QVl2rlJY23FkzPSVMtUAQxNsxHPZ7vqi+gu7wucNiOfIPNTh9avOr20Q==
+  dependencies:
+    "@glimmer/interfaces" "0.80.0"
+    "@glimmer/util" "0.80.0"
+    "@handlebars/parser" "~2.0.0"
+    simple-html-tokenizer "^0.5.10"
+
+"@glimmer/util@0.65.3":
+  version "0.65.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.65.3.tgz#354760f7394bf016f41f6222a7937c1a394ff418"
+  integrity sha512-3qXYC9GpHipAXT0oVec6vQ3xsZaWIgLxyN62S0l/xHnIa5pXu3vnX73zan282IS6Mi0RetxwGNyEBT9OPsYkqQ==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "0.65.3"
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/util@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.80.0.tgz#286ec9e2c8c9e2f364e49272a3baf9d0fe3dc40c"
+  integrity sha512-fvr4zyGVp58vzVajwTwbGwp0LmPxm2SVWkfIGFcCr9r2BmYD+9bd52I0u00LsZvNJQqFNyI8RB+qXThRMi+TiA==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "0.80.0"
+    "@simple-dom/interface" "^1.4.0"
+
 "@glimmer/vm-babel-plugins@0.77.5":
   version "0.77.5"
   resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.5.tgz#daffb6507aa6b08ec36f69d652897d339fdd0007"
   integrity sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
+
+"@glimmer/vm-babel-plugins@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.80.0.tgz#e9a6b496501eed367b94c928dc48a954830af3b5"
+  integrity sha512-ZW6+L+FzjDZngGj87zn3MRRA/MrchC7Con33mCcI36v8u48maheB351uhQe+fBVU300IfyzNMvAdwdVKS5VIFw==
+  dependencies:
+    babel-plugin-debug-macros "^0.3.4"
+
+"@glimmer/wire-format@0.65.3":
+  version "0.65.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.65.3.tgz#0478a822edaf7478aa3370592cab75c2cfaf5ecb"
+  integrity sha512-vqICHcO74K2nt40yWB1gpWRJJbK0q46NJ4ZWECikzCRKICm9QXz+LKryVpE4Zopyq8HUzR8sIP6zMoaLQ5BsRA==
+  dependencies:
+    "@glimmer/interfaces" "0.65.3"
+    "@glimmer/util" "0.65.3"
+
+"@glimmer/wire-format@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.80.0.tgz#bea3da7973a6a70611bf45cfc15592dbec132091"
+  integrity sha512-DAUEqUxq0ymuzRStw51DMhTrRZdCBVPZ7K63YFLRud3pojaApWxgeOFlsLua9nRqR6wYSSKS0y2E0n0tPnRndA==
+  dependencies:
+    "@glimmer/interfaces" "0.80.0"
+    "@glimmer/util" "0.80.0"
+
+"@handlebars/parser@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
+  integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
+
+"@handlebars/parser@~2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
+  integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -971,6 +1061,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@simple-dom/interface@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
+  integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
 
 "@types/fs-extra@^5.0.5":
   version "5.1.0"
@@ -1258,6 +1353,14 @@ broccoli-debug@^0.6.4, broccoli-debug@^0.6.5:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-file-creator@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
+  integrity sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
+
 broccoli-funnel@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz#0edf629569bc10bd02cc525f74b9a38e71366a75"
@@ -1340,7 +1443,7 @@ broccoli-persistent-filter@^2.2.1:
     sync-disk-cache "^1.3.3"
     walk-sync "^1.0.0"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
   integrity sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==
@@ -1724,6 +1827,38 @@ ember-router-generator@^2.0.0:
     semver "^6.1.1"
     silent-error "^1.1.1"
 
+"ember-source-3-28@npm:ember-source@3.28.1":
+  version "3.28.1"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.1.tgz#dbd00dde4e5660231c72574589e7705ed8c76b1d"
+  integrity sha512-dPedE1KBNiFllxzS8uiTWCf5Kofd6hrbJCt162UrTfEMZy6Pt4dZrX2kz0Dq/Fi57FrFAYkMM2cuhYCz2dbENw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/plugin-transform-block-scoping" "^7.8.3"
+    "@babel/plugin-transform-object-assign" "^7.8.3"
+    "@ember/edition-utils" "^1.2.0"
+    "@glimmer/vm-babel-plugins" "0.80.0"
+    babel-plugin-debug-macros "^0.3.3"
+    babel-plugin-filter-imports "^4.0.0"
+    broccoli-concat "^4.2.4"
+    broccoli-debug "^0.6.4"
+    broccoli-file-creator "^2.1.1"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^4.2.0"
+    chalk "^4.0.0"
+    ember-cli-babel "^7.23.0"
+    ember-cli-get-component-path-option "^1.0.0"
+    ember-cli-is-package-missing "^1.0.0"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-version-checker "^5.1.1"
+    ember-router-generator "^2.0.0"
+    inflection "^1.12.0"
+    jquery "^3.5.1"
+    resolve "^1.17.0"
+    semver "^7.3.4"
+    silent-error "^1.1.1"
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -1972,6 +2107,28 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
+"glimmer-compiler-ember-source-3-24@npm:@glimmer/compiler@0.65.3":
+  version "0.65.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.65.3.tgz#953d0fe131e5a8a09b247910867a3ccaddec9c19"
+  integrity sha512-DAzuOC4koGxn78yBNoGiTKszrmRxev39y4UkwLx9ElFiIx5g+lnvPUkCFN/7z/IPNh0o3D4Qtmp5nM6vHKoMlA==
+  dependencies:
+    "@glimmer/interfaces" "0.65.3"
+    "@glimmer/syntax" "0.65.3"
+    "@glimmer/util" "0.65.3"
+    "@glimmer/wire-format" "0.65.3"
+    "@simple-dom/interface" "^1.4.0"
+
+"glimmer-compiler-ember-source-3-28@npm:@glimmer/compiler@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.80.0.tgz#f825b2d5b55500c0a695f076c7a2fdd312a1e94e"
+  integrity sha512-oz72cvjNHXpKY1i9aJBiLQSkmqW1zbCGc1J/gIGTXeMC5tdJlDXve22eS2ZkNWI41ai3ClzpA0hIz5ju7qO8zw==
+  dependencies:
+    "@glimmer/interfaces" "0.80.0"
+    "@glimmer/syntax" "0.80.0"
+    "@glimmer/util" "0.80.0"
+    "@glimmer/wire-format" "0.80.0"
+    "@simple-dom/interface" "^1.4.0"
+
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -2175,7 +2332,7 @@ istextorbinary@2.1.0:
     editions "^1.1.1"
     textextensions "1 || 2"
 
-jquery@^3.5.0:
+jquery@^3.5.0, jquery@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
@@ -2866,6 +3023,11 @@ silent-error@^1.0.0, silent-error@^1.1.1:
   integrity sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==
   dependencies:
     debug "^2.2.0"
+
+simple-html-tokenizer@^0.5.10:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz#4c5186083c164ba22a7b477b7687ac056ad6b1d9"
+  integrity sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==
 
 slice-ansi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
* updates to dynamically retrieve list of compilers
* add support for testing @glimmer/compiler


```
Total precompile time using 'ember-source@3.24.5' 3501
Total precompile time using 'ember-source@3.25.4' 19191
Total precompile time using 'ember-source@3.28.1' 19041
Total precompile time using '@glimmer/compiler@0.80.0' 20495
Total precompile time using '@glimmer/compiler@0.65.3' 3221
```